### PR TITLE
toPassportConfig: use entryPoint for passport-saml

### DIFF
--- a/src/passport.js
+++ b/src/passport.js
@@ -6,6 +6,7 @@ function toPassportConfig(reader = {}) {
 
   const config = {
     identityProviderUrl,
+    entryPoint: identityProviderUrl,
     logoutUrl,
     cert: [].concat(signingCerts).pop(), // assumes the last cert is the most recent one
     identifierFormat


### PR DESCRIPTION
passport-saml does not know the property identityProviderUrl. 
instead of throwing an error, passport simply hangs.
entryPoint is the same as identityProviderUrl in passport-wsfed-saml2