### PR TITLE
feat(passport): passport config to support multiple signing certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ Additional configuration options supported: https://github.com/axios/axios#reque
 
 Returns a promise which resolves, if successful, to an instance of `MetadataReader`.
 
-### toPassportConfig(reader)
+### toPassportConfig(reader, options = { multipleCerts: false })
 
 Transforms metadata extracts for use in Passport strategy configuration. The following strategies are currently supported:
 
 * [passport-saml](http://npmjs.org/packages/passport-saml)
 * [passport-wsfed-saml2](http://npmjs.org/packages/passport-wsfed-saml2)
+
+When setting the `multipleCerts` options to true, an array of signing certificates are passed to the passport config instead of assuming the last certificate is the most recent one.
 
 ### claimsToCamelCase(claims, claimSchema)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Transforms metadata extracts for use in Passport strategy configuration. The fol
 * [passport-saml](http://npmjs.org/package/passport-saml)
 * [passport-wsfed-saml2](http://npmjs.org/package/passport-wsfed-saml2)
 
-When setting the `multipleCerts` options to true, an array of signing certificates are passed to the passport config instead of assuming the last certificate is the most recent one.
+Config:
+
+* `multipleCerts` (boolean): causes the full array of signing certificates to be passed to the passport config instead of assuming the last certificate is the most recent one. Note: this option is not compatible with [passport-wsfed-saml2](http://npmjs.org/package/passport-wsfed-saml2).
 
 ### claimsToCamelCase(claims, claimSchema)
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Returns a promise which resolves, if successful, to an instance of `MetadataRead
 
 Transforms metadata extracts for use in Passport strategy configuration. The following strategies are currently supported:
 
-* [passport-saml](http://npmjs.org/packages/passport-saml)
-* [passport-wsfed-saml2](http://npmjs.org/packages/passport-wsfed-saml2)
+* [passport-saml](http://npmjs.org/package/passport-saml)
+* [passport-wsfed-saml2](http://npmjs.org/package/passport-wsfed-saml2)
 
 When setting the `multipleCerts` options to true, an array of signing certificates are passed to the passport config instead of assuming the last certificate is the most recent one.
 

--- a/src/passport.js
+++ b/src/passport.js
@@ -1,13 +1,13 @@
 const debug = require('debug')('passport-saml-metadata');
 
-function toPassportConfig(reader = {}) {
+function toPassportConfig(reader = {}, options = { multipleCerts: false }) {
   const { identifierFormat, identityProviderUrl, logoutUrl, signingCerts } = reader;
 
   const config = {
     identityProviderUrl,
     entryPoint: identityProviderUrl,
     logoutUrl,
-    cert: [].concat(signingCerts).pop(), // assumes the last cert is the most recent one
+    cert: (!options.multipleCerts) ? [].concat(signingCerts).pop() : signingCerts,
     identifierFormat
   };
 

--- a/test/passport.test.js
+++ b/test/passport.test.js
@@ -4,7 +4,7 @@ const { toPassportConfig, claimsToCamelCase } = require('../src/passport');
 const reader = {
   identityProviderUrl: 'a',
   logoutUrl: 'b',
-  signingCerts: ['c'],
+  signingCerts: ['c', 'c2'],
   identifierFormat: 'd',
   claimSchema: require('./data/claim-schema.json')
 };
@@ -19,7 +19,17 @@ describe('passport helpers', () => {
       entryPoint: 'a',
       identityProviderUrl: 'a',
       logoutUrl: 'b',
-      cert: 'c',
+      cert: 'c2',
+      identifierFormat: 'd'
+    });
+  });
+
+  it('toPassportConfig() with multiple cert support', () => {
+    assert.deepStrictEqual(toPassportConfig(reader, { multipleCerts: true }), {
+      entryPoint: 'a',
+      identityProviderUrl: 'a',
+      logoutUrl: 'b',
+      cert: ['c', 'c2'],
       identifierFormat: 'd'
     });
   });


### PR DESCRIPTION
Hi,

I was having some trouble using passport-saml-metadata to create a Passport config to use with the passport-saml strategy.

When loading the IDP metadata, the last found signing certificate was assumed to be the most recent. In my case, this wasn't the certificate that was actually used for signing. 

Because the supported strategy passport-saml supports multiple signing certificates as an array (and as far is i can see the passport-wsfed-saml2 strategy doesn't), i added an options object to the `toPassportConfig` method to optionally allow multiple signing certificates.

Happy to hear your thoughts on this one.

Rob
