### PR TITLE
Add check for undefined cert

### DIFF
--- a/src/MetadataReader.js
+++ b/src/MetadataReader.js
@@ -118,8 +118,12 @@ export class MetadataReader {
 
   get encryptionCerts () {
     try {
-      return this.#query('//md:IDPSSODescriptor/md:KeyDescriptor[@use="encryption" or not(@use)]/sig:KeyInfo/sig:X509Data/sig:X509Certificate')
-        .map((node) => node.firstChild.data.replace(/[\r\n\t\s]/gm, ''))
+      const certs = this.#query('//md:IDPSSODescriptor/md:KeyDescriptor[@use="encryption" or not(@use)]/sig:KeyInfo/sig:X509Data/sig:X509Certificate')
+      if (!certs) {
+        throw new Error('No encryption certificate found')
+      }
+
+      return certs.map((node) => node.firstChild.data.replace(/[\r\n\t\s]/gm, ''))
     } catch (e) {
       if (this.#options.throwExceptions) {
         throw e
@@ -131,7 +135,7 @@ export class MetadataReader {
 
   get encryptionCert () {
     try {
-      return this.encryptionCerts[0].replace(/[\r\n\t\s]/gm, '')
+      return this.encryptionCerts[0]
     } catch (e) {
       if (this.#options.throwExceptions) {
         throw e
@@ -143,8 +147,12 @@ export class MetadataReader {
 
   get signingCerts () {
     try {
-      return this.#query('//md:IDPSSODescriptor/md:KeyDescriptor[@use="signing" or not(@use)]/sig:KeyInfo/sig:X509Data/sig:X509Certificate')
-        .map((node) => node.firstChild.data.replace(/[\r\n\t\s]/gm, ''))
+      const certs = this.#query('//md:IDPSSODescriptor/md:KeyDescriptor[@use="signing" or not(@use)]/sig:KeyInfo/sig:X509Data/sig:X509Certificate')
+      if (!certs) {
+        throw new Error('No signing certificate found')
+      }
+
+      return certs.map((node) => node.firstChild.data.replace(/[\r\n\t\s]/gm, ''))
     } catch (e) {
       if (this.#options.throwExceptions) {
         throw e
@@ -156,7 +164,7 @@ export class MetadataReader {
 
   get signingCert () {
     try {
-      return this.signingCerts[0].replace(/[\r\n\t\s]/gm, '')
+      return this.signingCerts[0]
     } catch (e) {
       if (this.#options.throwExceptions) {
         throw e


### PR DESCRIPTION
Query will return `undefined`  if a certificate is not present, this will cause a type error when calling` .replace()` on it in the `.map`

This slightly modifies the logic so that a more meaningful error is thrown.