### PR TITLE
feat: add new entityId() method to MetadataReader

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -8,6 +8,7 @@ declare class MetadataReader {
     get signingCerts(): any;
     get signingCert(): any;
     get claimSchema(): any;
+    get entityId(): any;
     #private;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@node-saml/node-saml": "^4.0.3",
-        "@xmldom/xmldom": "^0.8.3",
+        "@xmldom/xmldom": "^0.8.6",
         "axios": "^1.1.3",
         "debug": "^4.3.2",
         "lodash": "^4.17.20",

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "dist"
   ],
   "dependencies": {
-    "@xmldom/xmldom": "^0.8.3",
-    "axios": "^1.1.3",
-    "debug": "^4.3.2",
-    "lodash": "^4.17.20",
+    "@xmldom/xmldom": "^0.8.6",
+    "axios": "^1.2.1",
+    "debug": "^4.3.4",
+    "lodash": "^4.17.21",
     "@node-saml/node-saml": "^4.0.3",
     "xpath": "0.0.32"
   },

--- a/src/MetadataReader.js
+++ b/src/MetadataReader.js
@@ -189,6 +189,18 @@ export class MetadataReader {
       return {}
     }
   }
+
+  get entityId () {
+    try {
+      return this.#query('//md:EntityDescriptor/@entityID')[0].value.replace(/[\r\n\t\s]/gm, '')
+    } catch (e) {
+      if (this.#options.throwExceptions) {
+        throw e
+      } else {
+        return undefined
+      }
+    }
+  }
 }
 
 export default MetadataReader

--- a/src/MetadataReader.test.js
+++ b/src/MetadataReader.test.js
@@ -44,6 +44,10 @@ describe('MetadataReader', () => {
     test('claimSchema', () => {
       assert.deepStrictEqual(config.claimSchema, claimSchema)
     })
+
+    test('entityId', () => {
+      assert.deepStrictEqual(config.entityId, 'http://adfs.server.url/adfs/services/trust')
+    })
   })
 
   describe('handles no KeyDescriptor use attribute', () => {


### PR DESCRIPTION
Closes #40.

In addition to implementing the functionality required to satisfy the need described by #40, I have also taken the opportunity to upgrade dependencies, particularly `@xmldom/xmldom`, to address the security issue described by https://nvd.nist.gov/vuln/detail/CVE-2022-39353.